### PR TITLE
fix error within API function which prevents user being subscribed to a channel

### DIFF
--- a/classes/integration/subscriptions.php
+++ b/classes/integration/subscriptions.php
@@ -86,7 +86,7 @@ class subscriptions {
      */
     public function add_subscription_for_user($user, $group) {
         $rocketchatchannel = $this->channelapi->has_channel_for_group($group);
-        $rocketchatuser = $this->userapi->get_user($user);
+        $rocketchatuser = $this->userapi->get_user($user->id);
 
         $subscription = $this->has_subscription($rocketchatchannel, $rocketchatuser);
 


### PR DESCRIPTION
Found error:
$this->userapi->get_user 
expected int but object was provided... So users were unable to suscribe. Fixed.