### PR TITLE
Release v5.1-r3: sync reliability, web service hardening, tests and CI coverage

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,8 @@ Requires Moodle 5.1 (`2025041400`).
 - Test metadata uses PHPUnit attributes (`#[CoversClass]`, `#[DataProvider]`) instead of the deprecated
   doc-comment annotations (removed in PHPUnit 12).
 - CI uploads PHPUnit coverage to Codecov (badge in the README).
+- The web service functions are built on the `core_external` classes instead of the deprecated
+  `externallib.php` includes.
 
 ## Earlier releases
 

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_rocketchat';
-$plugin->version = 2026011802;
+$plugin->version = 2026061200;
 $plugin->requires = 2025041400;
-$plugin->release = 'v5.1-r2';
+$plugin->release = 'v5.1-r3';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
## Summary

- **Security:** the `local_rocketchat_*` web service functions now validate the system context and require the `local/rocketchat:manage` capability.
- Fix the scheduled "Sync students" task crashing on every run after the first one, and make user/channel/subscription sync null-safe against unreachable servers and failed API responses.
- Propagate enrolment suspensions again (`users.update` was called with an invalid user id) and fix event based sync for missing channels/users.
- Validate the link account form when the server returns no parseable response, and fix web service return values.
- Extensive PHPUnit coverage (API client, sync, observers, external functions, privacy, …) via `\curl::mock_response()`, PHPUnit attributes instead of doc-comment annotations, Codecov upload in CI.
- Migrate the web service functions to the `core_external` classes.
- Bump version to `2026061200` / `v5.1-r3` (tagged) and update `CHANGES.md`.

## Release

The release is tagged as `v5.1-r3` on the version-bump commit; please merge with a merge commit (no squash/rebase) so the tag stays reachable from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)